### PR TITLE
Support for non-string projection keys added including RavenDB.

### DIFF
--- a/Samples/ExampleHost/CountsProjectionBootstrapper.cs
+++ b/Samples/ExampleHost/CountsProjectionBootstrapper.cs
@@ -18,7 +18,7 @@ namespace LiquidProjections.ExampleHost
         private readonly Stopwatch stopwatch = new Stopwatch();
         private long eventCount = 0;
         private long transactionCount = 0;
-        private readonly EventMapBuilder<DocumentCountProjection, RavenProjectionContext> mapBuilder;
+        private readonly EventMapBuilder<DocumentCountProjection, string, RavenProjectionContext> mapBuilder;
 
         public CountsProjectionBootstrapper(Dispatcher dispatcher, Func<IAsyncDocumentSession> sessionFactory)
         {
@@ -56,9 +56,9 @@ namespace LiquidProjections.ExampleHost
             });
         }
 
-        private static EventMapBuilder<DocumentCountProjection, RavenProjectionContext> BuildEventMap()
+        private static EventMapBuilder<DocumentCountProjection, string, RavenProjectionContext> BuildEventMap()
         {
-            var map = new EventMapBuilder<DocumentCountProjection, RavenProjectionContext>();
+            var map = new EventMapBuilder<DocumentCountProjection, string, RavenProjectionContext>();
 
             map.Map<CountryRegisteredEvent>().As(async (e, ctx) =>
             {

--- a/Samples/ExampleHost/CountsProjectionBootstrapper.cs
+++ b/Samples/ExampleHost/CountsProjectionBootstrapper.cs
@@ -14,7 +14,7 @@ namespace LiquidProjections.ExampleHost
     {
         private readonly Dispatcher dispatcher;
         private readonly Func<IAsyncDocumentSession> sessionFactory;
-        private RavenProjector<DocumentCountProjection> projector;
+        private RavenProjector<DocumentCountProjection, string> projector;
         private readonly Stopwatch stopwatch = new Stopwatch();
         private long eventCount = 0;
         private long transactionCount = 0;
@@ -29,10 +29,17 @@ namespace LiquidProjections.ExampleHost
 
         public async Task Start()
         {
-            var lruCache = new LruProjectionCache<DocumentCountProjection>(20000, TimeSpan.FromSeconds(30), TimeSpan.FromMinutes(2),
-                () => DateTime.Now);
+            var lruCache = new LruProjectionCache<DocumentCountProjection>(
+                capacity: 20000,
+                minimumRetention: TimeSpan.FromSeconds(30),
+                maximumRetention: TimeSpan.FromMinutes(2),
+                getNow: () => DateTime.UtcNow);
 
-            projector = new RavenProjector<DocumentCountProjection>(sessionFactory, mapBuilder, batchSize: 20, cache: lruCache);
+            projector = new RavenProjector<DocumentCountProjection, string>(
+                sessionFactory,
+                mapBuilder,
+                batchSize: 20,
+                cache: lruCache);
 
             long lastCheckpoint = await projector.GetLastCheckpoint() ?? 0;
 
@@ -51,7 +58,8 @@ namespace LiquidProjections.ExampleHost
                     int ratePerSecond = (int)(eventCount / elapsedTotalSeconds);
 
                     Console.WriteLine(
-                        $"{DateTime.Now}: Processed {eventCount} events (rate: {ratePerSecond}/second, hits: {lruCache.Hits}, Misses: {lruCache.Misses})");
+                        $"{DateTime.Now}: Processed {eventCount} events (rate: {ratePerSecond}/second, " +
+                        $"hits: {lruCache.Hits}, Misses: {lruCache.Misses})");
                 }
             });
         }

--- a/Samples/ExampleHost/DocumentCountProjection.cs
+++ b/Samples/ExampleHost/DocumentCountProjection.cs
@@ -5,7 +5,7 @@ using LiquidProjections.RavenDB;
 
 namespace LiquidProjections.ExampleHost
 {
-    public class DocumentCountProjection : IHaveIdentity
+    public class DocumentCountProjection : IHaveIdentity<string>
     {
         public DocumentCountProjection()
         {
@@ -35,7 +35,8 @@ namespace LiquidProjections.ExampleHost
 
         public ValidityPeriod GetOrAddPeriod(int sequence)
         {
-            var period = Periods.FirstOrDefault(p => p.Sequence == sequence);
+            ValidityPeriod period = Periods.FirstOrDefault(p => p.Sequence == sequence);
+
             if (period == null)
             {
                 period = new ValidityPeriod
@@ -49,10 +50,7 @@ namespace LiquidProjections.ExampleHost
             return period;
         }
 
-        public override string ToString()
-        {
-            return string.Format("Id: {0}, Kind:{1} State:{2}", Id, Kind, State);
-        }
+        public override string ToString() => $"Id: {Id}, Kind:{Kind} State:{State}";
     }
 
     public class ValidityPeriod

--- a/Src/LiquidProjections.NHibernate/IHaveIdentity.cs
+++ b/Src/LiquidProjections.NHibernate/IHaveIdentity.cs
@@ -1,7 +1,7 @@
 namespace LiquidProjections.NHibernate
 {
-    public interface IHaveIdentity
+    public interface IHaveIdentity<TKey>
     {
-        string Id { get; set; }
+        TKey Id { get; set; }
     }
 }

--- a/Src/LiquidProjections.NHibernate/NHibernateProjector.cs
+++ b/Src/LiquidProjections.NHibernate/NHibernateProjector.cs
@@ -6,9 +6,8 @@ using NHibernate;
 
 namespace LiquidProjections.NHibernate
 {
-    // TODO: Support non-string keys
-    public sealed class NHibernateProjector<TProjection, TState>
-        where TProjection : class, IHaveIdentity, new()
+    public sealed class NHibernateProjector<TProjection, TKey, TState>
+        where TProjection : class, IHaveIdentity<TKey>, new()
         where TState : class, IProjectorState, new()
     {
         private readonly Func<ISession> sessionFactory;
@@ -18,7 +17,8 @@ namespace LiquidProjections.NHibernate
 
         public NHibernateProjector(
             Func<ISession> sessionFactory,
-            IEventMapBuilder<TProjection, NHibernateProjectionContext> eventMapBuilder,
+            IEventMapBuilder<TProjection, TKey, NHibernateProjectionContext> eventMapBuilder,
+
             int batchSize = 1,
             string stateKey = null)
         {
@@ -30,7 +30,7 @@ namespace LiquidProjections.NHibernate
             map = eventMapBuilder.Build();
         }
 
-        private void SetupHandlers(IEventMapBuilder<TProjection, NHibernateProjectionContext> eventMapBuilder)
+        private void SetupHandlers(IEventMapBuilder<TProjection, TKey, NHibernateProjectionContext> eventMapBuilder)
         {
             eventMapBuilder.HandleUpdatesAs(async (key, context, projector) =>
             {

--- a/Src/LiquidProjections.RavenDB/IHaveIdentity.cs
+++ b/Src/LiquidProjections.RavenDB/IHaveIdentity.cs
@@ -1,7 +1,7 @@
 namespace LiquidProjections.RavenDB
 {
-    public interface IHaveIdentity
+    public interface IHaveIdentity<TKey>
     {
-        string Id { get; set; }
+        TKey Id { get; set; }
     }
 }

--- a/Src/LiquidProjections.RavenDB/IProjectionCache.cs
+++ b/Src/LiquidProjections.RavenDB/IProjectionCache.cs
@@ -4,13 +4,14 @@ using System.Threading.Tasks;
 namespace LiquidProjections.RavenDB
 {
     /// <summary>
-    /// Defines a write-through cache that the <see cref="RavenProjector{TProjection}"/> can use to avoid unnecessary loads
+    /// Defines a write-through cache that the <see cref="RavenProjector{TProjection, TKey}"/> can use to avoid unnecessary loads
     /// of the projection.
+    /// Can be reused for multiple projectors.
     /// </summary>
-    public interface IProjectionCache<TProjection> 
+    public interface IProjectionCache<TProjection>
     {
         /// <summary>
-        /// Attempts to get the item identified by <paramref name="key"/> from the cache, or creates a new one. 
+        /// Attempts to get the item identified by <paramref name="key"/> in the database from the cache, or creates a new one. 
         /// </summary>
         /// <remarks>
         /// This method must be safe in multi-threaded scenarios. So multiple concurrent requests for the same key must always 
@@ -19,7 +20,7 @@ namespace LiquidProjections.RavenDB
         Task<TProjection> Get(string key, Func<Task<TProjection>> createProjection);
 
         /// <summary>
-        /// Removes the item identified by <paramref name="key"/> from the cache.
+        /// Removes the item identified by <paramref name="key"/> id the database from the cache.
         /// </summary>
         /// This method must be safe in multi-threaded scenarios and be idempotent. 
         /// </summary>

--- a/Src/LiquidProjections.RavenDB/PassthroughCache.cs
+++ b/Src/LiquidProjections.RavenDB/PassthroughCache.cs
@@ -3,7 +3,7 @@ using System.Threading.Tasks;
 
 namespace LiquidProjections.RavenDB
 {
-    internal class PassthroughCache<TProjection> : IProjectionCache<TProjection> where TProjection : IHaveIdentity
+    internal class PassthroughCache<TProjection> : IProjectionCache<TProjection>
     {
         public Task<TProjection> Get(string key, Func<Task<TProjection>> createProjection)
         {
@@ -12,7 +12,7 @@ namespace LiquidProjections.RavenDB
 
         public void Remove(string key)
         {
-            
+            // Do nothing. Nothing is cached anyway.
         }
     }
 }

--- a/Src/LiquidProjections.RavenDB/RavenProjector.cs
+++ b/Src/LiquidProjections.RavenDB/RavenProjector.cs
@@ -12,7 +12,11 @@ namespace LiquidProjections.RavenDB
         private readonly IProjectionCache<TProjection> cache;
         private IEventMap<RavenProjectionContext> map;
 
-        public RavenProjector(Func<IAsyncDocumentSession> sessionFactory, IEventMapBuilder<TProjection, RavenProjectionContext> eventMapBuilder, int batchSize = 1, IProjectionCache<TProjection> cache = null)
+        public RavenProjector(
+            Func<IAsyncDocumentSession> sessionFactory,
+            IEventMapBuilder<TProjection, string, RavenProjectionContext> eventMapBuilder,
+            int batchSize = 1,
+            IProjectionCache<TProjection> cache = null)
         {
             this.sessionFactory = sessionFactory;
             this.batchSize = batchSize;
@@ -28,7 +32,7 @@ namespace LiquidProjections.RavenDB
         /// </summary>
         public string CollectionName { get; set; }
 
-        private void SetupHandlers(IEventMapBuilder<TProjection, RavenProjectionContext> eventMapBuilder)
+        private void SetupHandlers(IEventMapBuilder<TProjection, string, RavenProjectionContext> eventMapBuilder)
         {
             eventMapBuilder.HandleUpdatesAs(async (key, context, projector) =>
             {

--- a/Src/LiquidProjections/EventMap.cs
+++ b/Src/LiquidProjections/EventMap.cs
@@ -4,13 +4,13 @@ using System.Threading.Tasks;
 
 namespace LiquidProjections
 {
-    public class EventMap<TProjection, TContext> : IEventMap<TContext>
+    public class EventMap<TProjection, TKey, TContext> : IEventMap<TContext>
     {
         private readonly Dictionary<Type, List<GetHandlerFor>> mappings = new Dictionary<Type, List<GetHandlerFor>>();
 
-        internal UpdateHandler<TContext, TProjection> Update { get; set; }
+        internal UpdateHandler<TKey, TContext, TProjection> Update { get; set; }
 
-        internal DeleteHandler<TContext> Delete { get; set; }
+        internal DeleteHandler<TKey, TContext> Delete { get; set; }
 
         internal CustomHandler<TContext> Do { get; set; }
 

--- a/Src/LiquidProjections/IEventMapBuilder.cs
+++ b/Src/LiquidProjections/IEventMapBuilder.cs
@@ -3,20 +3,23 @@ using System.Threading.Tasks;
 
 namespace LiquidProjections
 {
-    public interface IEventMapBuilder<in TProjection, TContext>
+    public interface IEventMapBuilder<in TProjection, out TKey, TContext>
     {
-        void HandleUpdatesAs(UpdateHandler<TContext, TProjection> handler);
+        void HandleUpdatesAs(UpdateHandler<TKey, TContext, TProjection> handler);
 
-        void HandleDeletesAs(DeleteHandler<TContext> handler);
+        void HandleDeletesAs(DeleteHandler<TKey, TContext> handler);
 
         void HandleCustomActionsAs(CustomHandler<TContext> handler);
 
         IEventMap<TContext> Build();
     }
 
-    public delegate Task UpdateHandler<TContext, out TProjection>(string key, TContext context, Func<TProjection, TContext, Task> projector);
+    public delegate Task UpdateHandler<in TKey, TContext, out TProjection>(
+        TKey key,
+        TContext context,
+        Func<TProjection, TContext, Task> projector);
 
-    public delegate Task DeleteHandler<in TContext>(string key, TContext context);
+    public delegate Task DeleteHandler<in TKey, in TContext>(TKey key, TContext context);
 
     public delegate Task CustomHandler<TContext>(TContext context, Func<TContext, Task> projector);
 }

--- a/Tests/LiquidProjections.NHibernate.Specs/NHibernateProjectorSpecs.cs
+++ b/Tests/LiquidProjections.NHibernate.Specs/NHibernateProjectorSpecs.cs
@@ -19,8 +19,8 @@ namespace LiquidProjections.NHibernate.Specs
         public class Given_a_sqlite_projector_with_an_in_memory_event_source : GivenWhenThen
         {
             protected readonly TaskCompletionSource<long> DispatchedCheckpointSource = new TaskCompletionSource<long>();
-            protected NHibernateProjector<ProductCatalogEntry, ProjectorState> Projector;
-            protected EventMapBuilder<ProductCatalogEntry, NHibernateProjectionContext> Events;
+            protected NHibernateProjector<ProductCatalogEntry, string, ProjectorState> Projector;
+            protected EventMapBuilder<ProductCatalogEntry, string, NHibernateProjectionContext> Events;
 
             private InMemorySQLiteDatabase database;
 
@@ -33,9 +33,9 @@ namespace LiquidProjections.NHibernate.Specs
                     database = new InMemorySQLiteDatabaseBuilder().Build();
                     UseThe(database.SessionFactory);
 
-                    Events = new EventMapBuilder<ProductCatalogEntry, NHibernateProjectionContext>();
+                    Events = new EventMapBuilder<ProductCatalogEntry, string, NHibernateProjectionContext>();
 
-                    Projector = new NHibernateProjector<ProductCatalogEntry, ProjectorState>(
+                    Projector = new NHibernateProjector<ProductCatalogEntry, string, ProjectorState>(
                         database.SessionFactory.OpenSession, Events, batchSize: 10);
 
                     var dispatcher = new Dispatcher(The<MemoryEventSource>());
@@ -68,7 +68,7 @@ namespace LiquidProjections.NHibernate.Specs
                     Events.Map<ProductAddedToCatalogEvent>()
                         .AsUpdateOf(productAddedToCatalogEvent => productAddedToCatalogEvent.ProductKey)
                         .Using((productCatalogEntry, productAddedToCatalogEvent, context) =>
-                            productCatalogEntry.Category = productAddedToCatalogEvent.Category);
+                                productCatalogEntry.Category = productAddedToCatalogEvent.Category);
                 });
 
                 When(async () =>
@@ -308,7 +308,7 @@ namespace LiquidProjections.NHibernate.Specs
         public class When_a_custom_state_key_is_set : GivenWhenThen
         {
             private readonly TaskCompletionSource<long> dispatchedCheckpointSource = new TaskCompletionSource<long>();
-            private NHibernateProjector<ProductCatalogEntry, ProjectorState> projector;
+            private NHibernateProjector<ProductCatalogEntry, string, ProjectorState> projector;
             private Transaction transaction;
             private InMemorySQLiteDatabase database;
 
@@ -321,9 +321,9 @@ namespace LiquidProjections.NHibernate.Specs
                     database = new InMemorySQLiteDatabaseBuilder().Build();
                     UseThe(database.SessionFactory);
 
-                    var events = new EventMapBuilder<ProductCatalogEntry, NHibernateProjectionContext>();
+                    var events = new EventMapBuilder<ProductCatalogEntry, string, NHibernateProjectionContext>();
 
-                    projector = new NHibernateProjector<ProductCatalogEntry, ProjectorState>(
+                    projector = new NHibernateProjector<ProductCatalogEntry, string, ProjectorState>(
                         database.SessionFactory.OpenSession, events, batchSize: 10, stateKey: "CatalogEntries");
 
                     var dispatcher = new Dispatcher(The<MemoryEventSource>());
@@ -372,8 +372,8 @@ namespace LiquidProjections.NHibernate.Specs
             }
         }
     }
-
-    public class ProductCatalogEntry : IHaveIdentity
+ 
+    public class ProductCatalogEntry : IHaveIdentity<string>
     {
         public virtual string Id { get; set; }
         public virtual string Category { get; set; }

--- a/Tests/LiquidProjections.RavenDB.Specs/RavenProjectorSpecs.cs
+++ b/Tests/LiquidProjections.RavenDB.Specs/RavenProjectorSpecs.cs
@@ -16,7 +16,7 @@ namespace LiquidProjections.RavenDB.Specs
             protected readonly TaskCompletionSource<long> DispatchedCheckpointSource = new TaskCompletionSource<long>();
             protected RavenProjector<ProductCatalogEntry> Projector;
             protected LruProjectionCache<ProductCatalogEntry> Cache;
-            protected EventMapBuilder<ProductCatalogEntry, RavenProjectionContext> Events;
+            protected EventMapBuilder<ProductCatalogEntry, string, RavenProjectionContext> Events;
 
             public Given_a_raven_projector_with_an_in_memory_event_source()
             {
@@ -29,7 +29,7 @@ namespace LiquidProjections.RavenDB.Specs
 
                     Cache = new LruProjectionCache<ProductCatalogEntry>(1000, TimeSpan.Zero, TimeSpan.FromHours(1), () => DateTime.Now);
 
-                    Events = new EventMapBuilder<ProductCatalogEntry, RavenProjectionContext>();
+                    Events = new EventMapBuilder<ProductCatalogEntry, string, RavenProjectionContext>();
 
                     Projector = new RavenProjector<ProductCatalogEntry>(store.OpenAsyncSession, Events, 10, Cache);
 

--- a/Tests/LiquidProjections.Specs/EventMapSpecs.cs
+++ b/Tests/LiquidProjections.Specs/EventMapSpecs.cs
@@ -17,7 +17,7 @@ namespace LiquidProjections.Specs
             {
                 Given(() =>
                 {
-                    var mapBuilder = new EventMapBuilder<ProductCatalogEntry, ProjectionContext>();
+                    var mapBuilder = new EventMapBuilder<ProductCatalogEntry, string, ProjectionContext>();
                     mapBuilder.Map<ProductAddedToCatalogEvent>().AsUpdateOf(e => e.ProductKey).Using((p, e, ctx) =>
                     {
                         p.Category = e.Category;
@@ -71,7 +71,7 @@ namespace LiquidProjections.Specs
             {
                 Given(() =>
                 {
-                    var mapBuilder = new EventMapBuilder<ProductCatalogEntry, ProjectionContext>();
+                    var mapBuilder = new EventMapBuilder<ProductCatalogEntry, string, ProjectionContext>();
                     mapBuilder.Map<ProductDiscontinuedEvent>().AsDeleteOf(e => e.ProductKey);
 
                     mapBuilder.HandleDeletesAs((key, context) =>
@@ -121,7 +121,7 @@ namespace LiquidProjections.Specs
             {
                 Given(() =>
                 {
-                    var mapBuilder = new EventMapBuilder<ProductCatalogEntry, ProjectionContext>();
+                    var mapBuilder = new EventMapBuilder<ProductCatalogEntry, string, ProjectionContext>();
                     mapBuilder.HandleCustomActionsAs((context, projector) => projector(context));
                     
                     mapBuilder.Map<ProductDiscontinuedEvent>().As((@event, context) =>
@@ -161,7 +161,7 @@ namespace LiquidProjections.Specs
             {
                 Given(() =>
                 {
-                    var mapBuilder = new EventMapBuilder<ProductCatalogEntry, ProjectionContext>();
+                    var mapBuilder = new EventMapBuilder<ProductCatalogEntry, string, ProjectionContext>();
                     mapBuilder.HandleUpdatesAs(async (key, context, projector) =>
                     {
                         projection = new ProductCatalogEntry
@@ -210,7 +210,7 @@ namespace LiquidProjections.Specs
             {
                 Given(() =>
                 {
-                    var mapBuilder = new EventMapBuilder<ProductCatalogEntry, ProjectionContext>();
+                    var mapBuilder = new EventMapBuilder<ProductCatalogEntry, string, ProjectionContext>();
                     mapBuilder.HandleUpdatesAs(async (key, context, projector) =>
                     {
                         projection = new ProductCatalogEntry
@@ -265,7 +265,7 @@ namespace LiquidProjections.Specs
                 {
                     action = () =>
                     {
-                        var mapBuilder = new EventMapBuilder<ProductCatalogEntry, ProjectionContext>();
+                        var mapBuilder = new EventMapBuilder<ProductCatalogEntry, string, ProjectionContext>();
 
                         mapBuilder.Map<ProductAddedToCatalogEvent>()
                             .When(e => e.Category == "Hybrids")

--- a/Tests/LiquidProjections.Specs/LiquidProjections.Specs.csproj
+++ b/Tests/LiquidProjections.Specs/LiquidProjections.Specs.csproj
@@ -80,6 +80,9 @@
       <Name>LiquidProjections</Name>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.


### PR DESCRIPTION
RavenDB uses keys converted to strings but does not store the converted keys in the projections.