### PR TITLE
Explicit registration of events which create projections

### DIFF
--- a/Samples/ExampleHost/CountsProjectionBootstrapper.cs
+++ b/Samples/ExampleHost/CountsProjectionBootstrapper.cs
@@ -69,7 +69,7 @@ namespace LiquidProjections.ExampleHost
                 });
             });
 
-            map.Map<WarrantAssignedEvent>().AsUpdateOf(e => e.Number).Using((p, e, ctx) =>
+            map.Map<WarrantAssignedEvent>().AsCreateOf(e => e.Number).Using((p, e, ctx) =>
             {
                 p.Type = "Warrant";
                 p.Kind = e.Kind;
@@ -77,7 +77,7 @@ namespace LiquidProjections.ExampleHost
                 p.State = e.InitialState;
             });
 
-            map.Map<CertificateIssuedEvent>().AsUpdateOf(e => e.Number).Using((p, e, ctx) =>
+            map.Map<CertificateIssuedEvent>().AsCreateOf(e => e.Number).Using((p, e, ctx) =>
             {
                 p.Type = "Certificate";
                 p.Kind = e.Kind;
@@ -93,7 +93,7 @@ namespace LiquidProjections.ExampleHost
                 p.State = e.InitialState;
             });
 
-            map.Map<LicenseGrantedEvent>().AsUpdateOf(e => e.Number).Using((p, e, ctx) =>
+            map.Map<LicenseGrantedEvent>().AsCreateOf(e => e.Number).Using((p, e, ctx) =>
             {
                 p.Type = "Audit";
                 p.Kind = e.Kind;
@@ -101,7 +101,7 @@ namespace LiquidProjections.ExampleHost
                 p.State = e.InitialState;
             });
 
-            map.Map<ContractNegotiatedEvent>().AsUpdateOf(e => e.Number).Using((p, e, ctx) =>
+            map.Map<ContractNegotiatedEvent>().AsCreateOf(e => e.Number).Using((p, e, ctx) =>
             {
                 p.Type = "Task";
                 p.Kind = e.Kind;
@@ -109,7 +109,7 @@ namespace LiquidProjections.ExampleHost
                 p.State = e.InitialState;
             });
 
-            map.Map<BondIssuedEvent>().AsUpdateOf(e => e.Number).Using((p, e, ctx) =>
+            map.Map<BondIssuedEvent>().AsCreateOf(e => e.Number).Using((p, e, ctx) =>
             {
                 p.Type = "IsolationCertificate";
                 p.Kind = e.Kind;

--- a/Samples/ExampleHost/JsonFileEventStore.cs
+++ b/Samples/ExampleHost/JsonFileEventStore.cs
@@ -59,10 +59,12 @@ namespace LiquidProjections.ExampleHost
                     Checkpoint = ++lastCheckpoint
                 };
 
-                string json = CurrentReader.ReadLine();
+                string json;
 
                 do
                 {
+                    json = CurrentReader.ReadLine();
+
                     if (json != null)
                     {
                         transaction.Events.Add(new EventEnvelope
@@ -87,10 +89,8 @@ namespace LiquidProjections.ExampleHost
                             Checkpoint = ++lastCheckpoint
                         };
                     }
-
-                    json = CurrentReader.ReadLine();
                 }
-                while ((json != null) && transactions.Count < pageSize);
+                while ((json != null) && (transactions.Count < pageSize));
 
                 return transactions.ToArray();
             });

--- a/Src/LiquidProjections.NHibernate/LiquidProjections.NHibernate.csproj
+++ b/Src/LiquidProjections.NHibernate/LiquidProjections.NHibernate.csproj
@@ -59,6 +59,7 @@
     <Compile Include="IHaveIdentity.cs" />
     <Compile Include="IProjectorState.cs" />
     <Compile Include="ITrackingState.cs" />
+    <Compile Include="NHibernateProjectorException.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="NHibernateProjectionContext.cs" />
     <Compile Include="NHibernateProjector.cs" />

--- a/Src/LiquidProjections.NHibernate/NHibernateProjectorException.cs
+++ b/Src/LiquidProjections.NHibernate/NHibernateProjectorException.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Runtime.Serialization;
+
+namespace LiquidProjections.NHibernate
+{
+    [Serializable]
+    public class NHibernateProjectorException : Exception
+    {
+        internal NHibernateProjectorException(string message)
+            : base(message)
+        {
+        }
+
+        internal NHibernateProjectorException(string message, Exception inner)
+            : base(message, inner)
+        {
+        }
+
+        protected NHibernateProjectorException(
+            SerializationInfo info,
+            StreamingContext context) : base(info, context)
+        {
+        }
+    }
+}

--- a/Src/LiquidProjections.RavenDB/IProjectionCache.cs
+++ b/Src/LiquidProjections.RavenDB/IProjectionCache.cs
@@ -7,8 +7,16 @@ namespace LiquidProjections.RavenDB
     /// Defines a write-through cache that the <see cref="RavenProjector{TProjection}"/> can use to avoid unnecessary loads
     /// of the projection.
     /// </summary>
-    public interface IProjectionCache<TProjection> 
+    public interface IProjectionCache<TProjection>
     {
+        /// <summary>
+        /// Adds a new item to the cache. 
+        /// </summary>
+        /// <remarks>
+        /// This method must be safe in multi-threaded scenarios.
+        /// </remarks>
+        void Add(TProjection projection);
+
         /// <summary>
         /// Attempts to get the item identified by <paramref name="key"/> from the cache, or creates a new one. 
         /// </summary>

--- a/Src/LiquidProjections.RavenDB/LiquidProjections.RavenDB.csproj
+++ b/Src/LiquidProjections.RavenDB/LiquidProjections.RavenDB.csproj
@@ -65,6 +65,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="RavenProjectionContext.cs" />
     <Compile Include="RavenProjector.cs" />
+    <Compile Include="RavenProjectorException.cs" />
     <Compile Include="RavenTrackingStore.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/Src/LiquidProjections.RavenDB/PassthroughCache.cs
+++ b/Src/LiquidProjections.RavenDB/PassthroughCache.cs
@@ -5,6 +5,11 @@ namespace LiquidProjections.RavenDB
 {
     internal class PassthroughCache<TProjection> : IProjectionCache<TProjection> where TProjection : IHaveIdentity
     {
+        public void Add(TProjection projection)
+        {
+
+        }
+
         public Task<TProjection> Get(string key, Func<Task<TProjection>> createProjection)
         {
             return createProjection();

--- a/Src/LiquidProjections.RavenDB/RavenProjector.cs
+++ b/Src/LiquidProjections.RavenDB/RavenProjector.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using Raven.Client;
 
@@ -34,17 +35,43 @@ namespace LiquidProjections.RavenDB
 
         private void SetupHandlers(IEventMapBuilder<TProjection, string, RavenProjectionContext> eventMapBuilder)
         {
+            eventMapBuilder.HandleCreatesAs(async (key, context, projector) =>
+            {
+                string databaseId = BuildDatabaseId(key);
+                var newProjection = new TProjection { Id = databaseId };
+
+                TProjection projection = await cache.Get(databaseId, async () =>
+                {
+                    TProjection existingProjection = await context.Session.LoadAsync<TProjection>(databaseId);
+                    return existingProjection ?? newProjection;
+                });
+
+                if (projection != newProjection)
+                {
+                    throw new RavenProjectorException(
+                        $"Cannot create projection with id {databaseId}. The projection already exists.");
+                }
+
+                await projector(newProjection, context);
+
+                await context.Session.StoreAsync(newProjection);
+            });
+
             eventMapBuilder.HandleUpdatesAs(async (key, context, projector) =>
             {
-                string id = $"{CollectionName}/{key}";
+                string databaseId = BuildDatabaseId(key);
 
-                TProjection projection = await cache.Get(id, async () =>
+                TProjection projection = await cache.Get(databaseId, async () =>
                 {
-                    var p = await context.Session.LoadAsync<TProjection>(id);
-                    return p ?? new TProjection
-                           {
-                               Id = id
-                           };
+                    TProjection existingProjection = await context.Session.LoadAsync<TProjection>(databaseId);
+
+                    if (existingProjection == null)
+                    {
+                        throw new RavenProjectorException(
+                            $"Cannot update projection with id {databaseId}. The projection does not exist.");
+                    }
+
+                    return existingProjection;
                 });
 
                 await projector(projection, context);
@@ -54,24 +81,29 @@ namespace LiquidProjections.RavenDB
 
             eventMapBuilder.HandleDeletesAs(async (key, context) =>
             {
-                string id = $"{CollectionName}/{key}";
+                string databaseId = BuildDatabaseId(key);
 
-                if (context.Session.Advanced.IsLoaded(id))
+                if (context.Session.Advanced.IsLoaded(databaseId))
                 {
-                    var projection = await context.Session.LoadAsync<TProjection>(id);
+                    var projection = await context.Session.LoadAsync<TProjection>(databaseId);
                     context.Session.Delete(projection);
                 }
                 else
                 {
-                    await context.Session.Advanced.DocumentStore.AsyncDatabaseCommands.DeleteAsync(id, null);
+                    await context.Session.Advanced.DocumentStore.AsyncDatabaseCommands.DeleteAsync(databaseId, null);
                 }
 
-                cache.Remove(id);
+                cache.Remove(databaseId);
             });
 
             eventMapBuilder.HandleCustomActionsAs((context, projector) => projector(context));
 
             map = eventMapBuilder.Build();
+        }
+
+        private string BuildDatabaseId(string key)
+        {
+            return $"{CollectionName}/{key}";
         }
 
         /// <summary>
@@ -88,10 +120,9 @@ namespace LiquidProjections.RavenDB
                     foreach (Transaction transaction in batch)
                     {
                         await ProjectTransaction(transaction, session);
-
-                        await StoreLastCheckpoint(session, transaction);
                     }
 
+                    await StoreLastCheckpoint(session, batch.Last());
                     await session.SaveChangesAsync();
                 }
             }

--- a/Src/LiquidProjections.RavenDB/RavenProjectorException.cs
+++ b/Src/LiquidProjections.RavenDB/RavenProjectorException.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Runtime.Serialization;
+
+namespace LiquidProjections.RavenDB
+{
+    [Serializable]
+    public class RavenProjectorException : Exception
+    {
+        internal RavenProjectorException(string message)
+            : base(message)
+        {
+        }
+
+        internal RavenProjectorException(string message, Exception inner)
+            : base(message, inner)
+        {
+        }
+
+        protected RavenProjectorException(
+            SerializationInfo info,
+            StreamingContext context) : base(info, context)
+        {
+        }
+    }
+}

--- a/Src/LiquidProjections/EventMap.cs
+++ b/Src/LiquidProjections/EventMap.cs
@@ -8,6 +8,8 @@ namespace LiquidProjections
     {
         private readonly Dictionary<Type, List<GetHandlerFor>> mappings = new Dictionary<Type, List<GetHandlerFor>>();
 
+        internal CreateHandler<TKey, TContext, TProjection> Create { get; set; }
+
         internal UpdateHandler<TKey, TContext, TProjection> Update { get; set; }
 
         internal DeleteHandler<TKey, TContext> Delete { get; set; }

--- a/Src/LiquidProjections/IEventMapBuilder.cs
+++ b/Src/LiquidProjections/IEventMapBuilder.cs
@@ -5,6 +5,8 @@ namespace LiquidProjections
 {
     public interface IEventMapBuilder<in TProjection, out TKey, TContext>
     {
+        void HandleCreatesAs(CreateHandler<TKey, TContext, TProjection> handler);
+
         void HandleUpdatesAs(UpdateHandler<TKey, TContext, TProjection> handler);
 
         void HandleDeletesAs(DeleteHandler<TKey, TContext> handler);
@@ -13,6 +15,11 @@ namespace LiquidProjections
 
         IEventMap<TContext> Build();
     }
+
+    public delegate Task CreateHandler<in TKey, TContext, out TProjection>(
+        TKey key,
+        TContext context,
+        Func<TProjection, TContext, Task> projector);
 
     public delegate Task UpdateHandler<in TKey, TContext, out TProjection>(
         TKey key,


### PR DESCRIPTION
Events which create projections separated from events which update projections in event maps:

```
            map.Map<WarrantAssignedEvent>().AsCreateOf(e => e.Number).Using((p, e, ctx) =>
            {
                p.Type = "Warrant";
                p.Kind = e.Kind;
                p.Country = e.Country;
                p.State = e.InitialState;
            });

            map.Map<StateTransitionedEvent>()
                .When(e => e.State != "Closed")
                .AsUpdateOf(e => e.DocumentNumber).Using((p, e, ctx) => p.State = e.State);
```

Fixes #45 