### PR TITLE
Slightly improved version of WithWaitCancellation

### DIFF
--- a/Src/LiquidProjections.NEventStore/TaskExtensions.cs
+++ b/Src/LiquidProjections.NEventStore/TaskExtensions.cs
@@ -6,24 +6,39 @@ namespace LiquidProjections.NEventStore
 {
     internal static class TaskExtensions
     {
-        public static async Task<TResult> WithWaitCancellation<TResult>(this Task<TResult> task,
+        public static Task<TResult> WithWaitCancellation<TResult>(this Task<TResult> task,
             CancellationToken cancellationToken)
         {
-            using (var combined = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken))
+            var tcs = new TaskCompletionSource<TResult>();
+            var registration = cancellationToken.Register(s =>
             {
-                var delayTask = Task.Delay(Timeout.Infinite, combined.Token);
-                Task completedTask = await Task.WhenAny(task, delayTask);
-                if (completedTask == task)
+                var source = (TaskCompletionSource<TResult>) s;
+                source.TrySetCanceled();
+            }, tcs);
+
+            task.ContinueWith((t, s) =>
+            {
+                var tcsAndRegistration = (Tuple<TaskCompletionSource<TResult>, CancellationTokenRegistration>) s;
+
+                if (t.IsFaulted && t.Exception!= null)
                 {
-                    combined.Cancel();
-                    return await task;
+                    tcsAndRegistration.Item1.TrySetException(t.Exception.InnerException);
                 }
-                else
+
+                if (t.IsCanceled)
                 {
-                    cancellationToken.ThrowIfCancellationRequested();
-                    throw new InvalidOperationException("Infinite delay task completed.");
+                    tcsAndRegistration.Item1.TrySetCanceled();
                 }
-            }
+
+                if (t.IsCompleted)
+                {
+                    tcsAndRegistration.Item1.TrySetResult(t.Result);
+                }
+
+                tcsAndRegistration.Item2.Dispose();
+            }, Tuple.Create(tcs, registration), CancellationToken.None, TaskContinuationOptions.ExecuteSynchronously, TaskScheduler.Default);
+
+            return tcs.Task;
         }
     }
 }


### PR DESCRIPTION
Slightly improved version of WaitWithCancellation which doesn't use `Task.Delay `but a `TaskCompletionSource`. 

The implementation is

- Closure allocation free
- Should be less resource intensive

We might need to consider Task{Creation/Continuation}Options.RunContinuationsAsynchronously in the TaskCompletionSource constructor. I fairly certain it is not required here but have a look for yourself

https://blogs.msdn.microsoft.com/pfxteam/2015/02/02/new-task-apis-in-net-4-6/