### PR TITLE
Introduced an ExceptionPolicy

### DIFF
--- a/Src/LiquidProjections.NHibernate/LiquidProjections.NHibernate.csproj
+++ b/Src/LiquidProjections.NHibernate/LiquidProjections.NHibernate.csproj
@@ -62,6 +62,7 @@
     </Compile>
     <Compile Include="App_Packages\FluidCaching.Sources\FluidCaching.cs" />
     <Compile Include="EnumerableExtensions.cs" />
+    <Compile Include="ShouldRetry.cs" />
     <Compile Include="IHaveIdentity.cs" />
     <Compile Include="INHibernateChildProjector.cs" />
     <Compile Include="IProjectorState.cs" />

--- a/Src/LiquidProjections.NHibernate/ShouldRetry.cs
+++ b/Src/LiquidProjections.NHibernate/ShouldRetry.cs
@@ -1,0 +1,10 @@
+namespace LiquidProjections.NHibernate
+{
+    /// <summary>
+    /// A delegate that can be implemented to retry projecting a batch of transactions when it fails.
+    /// </summary>
+    /// <returns>Returns true if the projector should retry to project the batch of transactions, false if it shoud fail with the specified exception.</returns>
+    /// <param name="exception">The exception that occured that caused this batch to fail.</param>
+    /// <param name="attempts">The number of attempts that were made to project this batch of transactions.</param>
+    public delegate bool ShouldRetry(ProjectionException exception, int attempts);
+}

--- a/Src/LiquidProjections.RavenDB/LiquidProjections.RavenDB.csproj
+++ b/Src/LiquidProjections.RavenDB/LiquidProjections.RavenDB.csproj
@@ -74,6 +74,7 @@
     <Compile Include="RavenProjectionContext.cs" />
     <Compile Include="RavenProjector.cs" />
     <Compile Include="RavenTrackingStore.cs" />
+    <Compile Include="ShouldRetry.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\LiquidProjections\LiquidProjections.csproj">

--- a/Src/LiquidProjections.RavenDB/ShouldRetry.cs
+++ b/Src/LiquidProjections.RavenDB/ShouldRetry.cs
@@ -1,0 +1,10 @@
+namespace LiquidProjections.RavenDB
+{
+    /// <summary>
+    /// A delegate that can be implemented to retry projecting a batch of transactions when it fails.
+    /// </summary>
+    /// <returns>Returns true if the projector should retry to project the batch of transactions, false if it shoud fail with the specified exception.</returns>
+    /// <param name="exception">The exception that occured that caused this batch to fail.</param>
+    /// <param name="attempts">The number of attempts that were made to project this batch of transactions.</param>
+    public delegate bool ShouldRetry(ProjectionException exception, int attempts);
+}

--- a/Src/LiquidProjections/LiquidProjections.csproj
+++ b/Src/LiquidProjections/LiquidProjections.csproj
@@ -74,6 +74,7 @@
     <Compile Include="Projector.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="ProjectionException.cs" />
+    <Compile Include="ShouldRetry.cs" />
     <Compile Include="TrackingService.cs" />
     <Compile Include="Transaction.cs" />
   </ItemGroup>

--- a/Src/LiquidProjections/ShouldRetry.cs
+++ b/Src/LiquidProjections/ShouldRetry.cs
@@ -1,0 +1,10 @@
+namespace LiquidProjections
+{
+    /// <summary>
+    /// A delegate that can be implemented to retry projecting a transaction when it fails.
+    /// </summary>
+    /// <returns>Returns true if the projector should retry to project the transaction, false if it shoud fail with the specified exception.</returns>
+    /// <param name="exception">The exception that occured that caused this batch to fail.</param>
+    /// <param name="attempts">The number of attempts that were made to project this transaction.</param>
+    public delegate bool ShouldRetry(ProjectionException exception, int attempts);
+}

--- a/Tests/LiquidProjections.RavenDB.Specs/RavenProjectorSpecs.cs
+++ b/Tests/LiquidProjections.RavenDB.Specs/RavenProjectorSpecs.cs
@@ -1593,6 +1593,70 @@ namespace LiquidProjections.RavenDB.Specs
                     .Which.TransactionBatch.Should().BeEquivalentTo(The<Transaction>());
             }
         }
+
+        public class When_event_handling_fails_with_a_custom_exception_policy :
+            Given_a_raven_projector_with_an_in_memory_event_source
+        {
+            private bool succeeded;
+            private int numerOfFailedAttempts;
+            private const int NumberOfTimesToFail = 3;
+
+            public When_event_handling_fails_with_a_custom_exception_policy()
+            {
+                Given(() =>
+                {
+                    UseThe(new InvalidOperationException());
+
+                    Events.Map<CategoryDiscontinuedEvent>().As((@event, context) =>
+                    {
+                        if (numerOfFailedAttempts < NumberOfTimesToFail)
+                        {
+                            throw The<InvalidOperationException>();
+                        }
+
+                        succeeded = true;
+                    });
+
+                    StartProjecting();
+
+                    Subject.ShouldRetry = (exception, attempts) =>
+                    {
+                        numerOfFailedAttempts = attempts;
+                        if (attempts <= NumberOfTimesToFail)
+                        {
+                            return true;
+                        }
+
+                        return false;
+                    };
+
+                    UseThe(new Transaction
+                    {
+                        Events = new[]
+                        {
+                            UseThe(new EventEnvelope
+                            {
+                                Body = new CategoryDiscontinuedEvent()
+                            })
+                        }
+                    });
+                });
+
+                When(() => The<MemoryEventSource>().Write(The<Transaction>()));
+            }
+
+            [Fact]
+            public void Then_it_should_try_again()
+            {
+                numerOfFailedAttempts.Should().Be(NumberOfTimesToFail);
+            }
+
+            [Fact]
+            public void Then_it_should_succeed()
+            {
+                succeeded.Should().BeTrue();
+            }
+        }
     }
 
     public class ProductCatalogEntry : IHaveIdentity


### PR DESCRIPTION
This policy can be used to intercept exceptions when handling a batch of transactions, and if desired, retry it